### PR TITLE
Better `copyAssets` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
   "name": "rnpm-plugin-link",
-  "version": "1.0.0",
-  "description": "rnpm plugin for linking dependencies",
+  "version": "1.1.0",
+  "description": "rnpm plugin that links native dependencies to your project",
   "main": "index.js",
   "keywords": [
     "rnpm",
     "react-native",
     "react-native link"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rnpm/rnpm.git"
+  },
   "engines": {
     "node": ">= 4.0.0"
   },
@@ -25,11 +29,11 @@
   "dependencies": {
     "fs-extra": "^0.26.2",
     "lodash.flowright": "^3.2.1",
+    "lodash.groupby": "^3.1.1",
+    "mime": "^1.3.4",
     "npmlog": "^2.0.0",
+    "plist": "^1.2.0",
     "xcode": "^0.8.2"
-  },
-  "peerDependencies": {
-    "rnpm": "^1.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.5",

--- a/src/action.js
+++ b/src/action.js
@@ -4,6 +4,9 @@ const log = require('npmlog');
 const registerDependencyAndroid = require('./android/registerNativeModule');
 const registerDependencyIOS = require('./ios/registerNativeModule');
 const copyAssetsAndroid = require('./android/copyAssets');
+const copyAssetsIOS = require('./ios/copyAssets');
+
+log.heading = 'rnpm-link';
 
 /**
  * Returns an array of dependencies that should be linked/checked.
@@ -47,9 +50,14 @@ module.exports = function link(config, args) {
         registerDependencyIOS(dependencyConfig.ios, project.ios);
       }
 
-      if (project.android && dependencyConfig.assets.length > 0) {
+      if (project.android && dependencyConfig.assets) {
         log.info(`Copying assets from ${name} to android project`);
         copyAssetsAndroid(dependencyConfig.assets, project.android.assetsPath);
+      }
+
+      if (project.ios && dependencyConfig.assets) {
+        log.info(`Linking assets from ${name} to ios project`);
+        copyAssetsIOS(dependencyConfig.assets, project.ios);
       }
     });
 };

--- a/src/android/copyAssets.js
+++ b/src/android/copyAssets.js
@@ -1,10 +1,21 @@
 const fs = require('fs-extra');
+const utils = require('../utils');
+const path = require('path');
 
 /**
  * Copies each file from an array of assets provided to targetPath directory
+ *
+ * For now, the only types of files that are handled are:
+ * - Fonts (otf, ttf) - copied to targetPath/fonts under original name
  */
-module.exports = function copyAssetsAndroid(assets, targetPath) {
-  (assets || []).forEach(asset => {
-    fs.copySync(asset, targetPath);
+module.exports = function copyAssetsAndroid(files, targetPath) {
+  const assets = utils.groupByType(files);
+
+  (assets.font || []).forEach(asset => {
+    const fileName = path.basename(asset);
+    fs.copySync(
+      asset,
+      path.join(targetPath, 'fonts', fileName)
+    );
   });
 };

--- a/src/ios/copyAssets.js
+++ b/src/ios/copyAssets.js
@@ -1,0 +1,63 @@
+const fs = require('fs-extra');
+const utils = require('../utils');
+const path = require('path');
+const xcode = require('xcode');
+const log = require('npmlog');
+const plistParser = require('plist');
+
+/**
+ * This function works in a similar manner to its Android version,
+ * except it does not copies fonts but creates XCode Group references
+ */
+module.exports = function copyAssetsIOS(files, projectConfig) {
+  const project = xcode.project(projectConfig.pbxprojPath).parseSync();
+  const assets = utils.groupByType(files);
+  const plistPath = path.join(
+    projectConfig.sourceDir,
+    project.getBuildProperty('INFOPLIST_FILE')
+  );
+
+  if (!fs.existsSync(plistPath)) {
+    return log.error(
+      'ERRPLIST',
+      `Could not locate Info.plist file at ${plistPath}. Check if your project has Info.plist set properly`
+    );
+  }
+
+  if (!project.pbxGroupByName('Resources')) {
+    return log.error(
+      'ERRGROUP',
+      `Group 'Resources' does not exist in your XCode project. See ` +
+      `https://developer.apple.com/library/ios/recipes/xcode_help-structure_navigator/articles/Creating_a_Group.html ` +
+      `for instructions on setting it up.`
+    );
+  }
+
+  const plist = plistParser.parse(
+    fs.readFileSync(plistPath, 'utf-8')
+  );
+
+  const fonts = (assets.font || [])
+    .map(asset =>
+      project.addResourceFile(
+        path.relative(projectConfig.sourceDir, asset),
+        {
+          target: project.getFirstTarget().uuid,
+        }
+      )
+    )
+    .filter(file => file)   // xcode returns false if file is already there
+    .map(file => file.basename);
+
+  plist.UIAppFonts = (plist.UIAppFonts || []).concat(fonts);
+
+  fs.writeFileSync(
+    projectConfig.pbxprojPath,
+    project.writeSync()
+  );
+
+  fs.writeFileSync(
+    plistPath,
+    plistParser.build(plist)
+  );
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,16 @@
+const groupBy = require('lodash.groupby');
+const mime = require('mime');
+
+/**
+ * Since there are no officialy registered MIME types
+ * for ttf/otf yet http://www.iana.org/assignments/media-types/media-types.xhtml,
+ * we define two non-standard ones for the sake of parsing
+ */
+mime.define({
+  'font/opentype': ['otf'],
+  'font/truetype': ['ttf'],
+});
+
+exports.groupByType = function groupByType(assets) {
+  return groupBy(assets, type => mime.lookup(type).split('/')[0]);
+};


### PR DESCRIPTION
It now detects file type and handles fonts differently than the rest (well, for now it does nothing apart from that but can be easily patched in the future)

For Android, it just copies all the fonts to `targetPath/fonts` folder preserving the original name.

For iOS, it creates group reference to original fonts directory.