### PR TITLE
Fix one issue with info.plist path

### DIFF
--- a/src/ios/copyAssets.js
+++ b/src/ios/copyAssets.js
@@ -14,7 +14,7 @@ module.exports = function copyAssetsIOS(files, projectConfig) {
   const assets = utils.groupByType(files);
   const plistPath = path.join(
     projectConfig.sourceDir,
-    project.getBuildProperty('INFOPLIST_FILE')
+    project.getBuildProperty('INFOPLIST_FILE').replace(/"/g, '')
   );
 
   if (!fs.existsSync(plistPath)) {


### PR DESCRIPTION
Because `project.getBuildProperty('INFOPLIST_FILE')` returns e.g. `"/src/Info.plist"` and we need to remove quotes. This has different behaviour when using with `npm link` apparently since I am not experiencing that locally.