### PR TITLE
Cut $(SRCROOT) from pblistPath

### DIFF
--- a/src/ios/copyAssets.js
+++ b/src/ios/copyAssets.js
@@ -14,7 +14,7 @@ module.exports = function copyAssetsIOS(files, projectConfig) {
   const assets = groupFilesByType(files);
   const plistPath = path.join(
     projectConfig.sourceDir,
-    project.getBuildProperty('INFOPLIST_FILE').replace(/"/g, '')
+    project.getBuildProperty('INFOPLIST_FILE').replace(/"/g, '').replace('$(SRCROOT)', '')
   );
 
   if (!fs.existsSync(plistPath)) {


### PR DESCRIPTION
It seems Cocoapods adds this to pbxProject (unconfirmed) and this line is breaking plist parsing. 