### PR TITLE
Update to latest `rnpm` interface

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -23,9 +23,10 @@ const getProjectDependencies = () => {
  * If optional argument [packageName] is provided, it's the only one that's checked
  */
 module.exports = function link(config, args) {
-  const project = config.getProjectConfig();
 
-  if (!project) {
+  try {
+    const project = config.getProjectConfig();
+  } catch (err) {
     log.error('ERRPACKAGEJSON', `No package found. Are you sure it's a React Native project?`);
     return;
   }


### PR DESCRIPTION
Our recent changes introduced possible error to be thrown when `package.json` does not exist. This pull request updates our interface to that so we still keep printing out nice, readable message after all. 