### PR TITLE
Add project assets if they are present

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lodash.flowright": "^3.2.1",
     "lodash.groupby": "^3.1.1",
     "lodash.union": "^3.1.0",
+    "lodash.uniq": "^3.2.2",
     "mime": "^1.3.4",
     "npmlog": "^2.0.0",
     "plist": "^1.2.0",

--- a/src/action.js
+++ b/src/action.js
@@ -33,32 +33,42 @@ module.exports = function link(config, args) {
   const packageName = args[0];
   const dependencies = packageName ? [packageName] : getProjectDependencies();
 
+  const copyAssets = (assets) => {
+    if (project.ios) {
+      copyAssetsIOS(assets, project.ios);
+    }
+
+    if (project.android) {
+      copyAssetsAndroid(assets, project.android.assetsPath);
+    }
+  };
+
+  if (!isEmpty(project.assets)) {
+    log.info('Linking project assets');
+    copyAssets(project.assets);
+  }
+
   dependencies
     .forEach(name => {
-      const dependencyConfig = config.getDependencyConfig(name);
+      const dependency = config.getDependencyConfig(name);
 
-      if (!dependencyConfig) {
+      if (!dependency) {
         return log.warn('ERRINVALIDPROJ', `Project ${name} is not a react-native library`);
       }
 
-      if (project.android && dependencyConfig.android) {
+      if (project.android && dependency.android) {
         log.info(`Linking ${name} android dependency`);
-        registerDependencyAndroid(name, dependencyConfig.android, project.android);
+        registerDependencyAndroid(name, dependency.android, project.android);
       }
 
-      if (project.ios && dependencyConfig.ios) {
+      if (project.ios && dependency.ios) {
         log.info(`Linking ${name} ios dependency`);
-        registerDependencyIOS(dependencyConfig.ios, project.ios);
+        registerDependencyIOS(dependency.ios, project.ios);
       }
 
-      if (project.android && !isEmpty(dependencyConfig.assets)) {
-        log.info(`Copying assets from ${name} to android project`);
-        copyAssetsAndroid(dependencyConfig.assets, project.android.assetsPath);
-      }
-
-      if (project.ios && !isEmpty(dependencyConfig.assets)) {
-        log.info(`Linking assets from ${name} to ios project`);
-        copyAssetsIOS(dependencyConfig.assets, project.ios);
+      if (!isEmpty(dependency.assets)) {
+        log.info(`Linking assets from ${name}`);
+        copyAssets(dependency.assets);
       }
     });
 };

--- a/src/action.js
+++ b/src/action.js
@@ -33,14 +33,18 @@ module.exports = function link(config, args) {
 
   const packageName = args[0];
 
-  const dependencies = (packageName ? [packageName] : getProjectDependencies())
+  const dependencies =
+    (packageName ? [packageName] : getProjectDependencies())
     .map(name => ({
       config: config.getDependencyConfig(name),
       name,
     }))
     .filter(dependency => {
       if (!dependency.config) {
-        log.warn('ERRINVALIDPROJ', `Project ${dependency.name} is not a react-native library`);
+        log.warn(
+          'ERRINVALIDPROJ',
+          `Project ${dependency.name} is not a react-native library`
+        );
         return false;
       }
       return true;
@@ -50,7 +54,11 @@ module.exports = function link(config, args) {
     .forEach(dependency => {
       if (project.android && dependency.config.android) {
         log.info(`Linking ${dependency.name} android dependency`);
-        registerDependencyAndroid(dependency.name, dependency.config.android, project.android);
+        registerDependencyAndroid(
+          dependency.name,
+          dependency.config.android,
+          project.android
+        );
       }
 
       if (project.ios && dependency.config.ios) {

--- a/src/action.js
+++ b/src/action.js
@@ -35,20 +35,20 @@ module.exports = function link(config, args) {
 
   const dependencies =
     (packageName ? [packageName] : getProjectDependencies())
-    .map(name => ({
-      config: config.getDependencyConfig(name),
-      name,
-    }))
-    .filter(dependency => {
-      if (!dependency.config) {
+    .map(name => {
+      try {
+        return {
+          config: config.getDependencyConfig(name),
+          name,
+        };
+      } catch (err) {
         log.warn(
           'ERRINVALIDPROJ',
-          `Project ${dependency.name} is not a react-native library`
+          `Project ${name} is not a react-native library`
         );
-        return false;
       }
-      return true;
-    });
+    })
+    .filter(dependency => dependency);
 
   dependencies.forEach(dependency => {
     if (project.android && dependency.config.android) {

--- a/src/action.js
+++ b/src/action.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const log = require('npmlog');
+const uniq = require('lodash.uniq');
 
 const isEmpty = require('./isEmpty');
 const registerDependencyAndroid = require('./android/registerNativeModule');
@@ -48,19 +49,22 @@ module.exports = function link(config, args) {
   dependencies
     .forEach(dependency => {
       if (project.android && dependency.config.android) {
-        log.info(`Linking ${name} android dependency`);
-        registerDependencyAndroid(name, dependency.android, project.android);
+        log.info(`Linking ${dependency.name} android dependency`);
+        registerDependencyAndroid(dependency.name, dependency.config.android, project.android);
       }
 
       if (project.ios && dependency.config.ios) {
-        log.info(`Linking ${name} ios dependency`);
+        log.info(`Linking ${dependency.name} ios dependency`);
         registerDependencyIOS(dependency.config.ios, project.ios);
       }
     });
 
-  const assets = dependencies.reduce(
-    (assets, dependency) => assets.concat(dependency.config.assets),
-    project.assets
+  const assets = uniq(
+    dependencies.reduce(
+      (assets, dependency) => assets.concat(dependency.config.assets),
+      project.assets
+    ),
+    asset => path.basename(asset)
   );
 
   if (isEmpty(assets)) {

--- a/src/action.js
+++ b/src/action.js
@@ -50,22 +50,21 @@ module.exports = function link(config, args) {
       return true;
     });
 
-  dependencies
-    .forEach(dependency => {
-      if (project.android && dependency.config.android) {
-        log.info(`Linking ${dependency.name} android dependency`);
-        registerDependencyAndroid(
-          dependency.name,
-          dependency.config.android,
-          project.android
-        );
-      }
+  dependencies.forEach(dependency => {
+    if (project.android && dependency.config.android) {
+      log.info(`Linking ${dependency.name} android dependency`);
+      registerDependencyAndroid(
+        dependency.name,
+        dependency.config.android,
+        project.android
+      );
+    }
 
-      if (project.ios && dependency.config.ios) {
-        log.info(`Linking ${dependency.name} ios dependency`);
-        registerDependencyIOS(dependency.config.ios, project.ios);
-      }
-    });
+    if (project.ios && dependency.config.ios) {
+      log.info(`Linking ${dependency.name} ios dependency`);
+      registerDependencyIOS(dependency.config.ios, project.ios);
+    }
+  });
 
   const assets = uniq(
     dependencies.reduce(


### PR DESCRIPTION
This is related to rnpm pr. The only thing that has changed is that we `map` dependency configs first into an array, so we can split main function into smaller bits and re-use that array.