### PR TITLE
Fix the path seperator when searching for iOS header files

### DIFF
--- a/src/ios/getHeaderSearchPath.js
+++ b/src/ios/getHeaderSearchPath.js
@@ -47,6 +47,6 @@ module.exports = function getHeaderSearchPath(sourceDir, headers) {
   );
 
   return directories.length === 1
-    ? `"$(SRCROOT)/${path.relative(sourceDir, directories[0])}"`
-    : `"$(SRCROOT)/${path.relative(sourceDir, getOuterDirectory(directories))}/**"`;
+    ? `"$(SRCROOT)${path.sep}${path.relative(sourceDir, directories[0])}"`
+    : `"$(SRCROOT)${path.sep}${path.relative(sourceDir, getOuterDirectory(directories))}/**"`;
 };


### PR DESCRIPTION
Tests fail on Windows since an incorrect path separator was used. Instead of hard coding `\`, this PR basically adds `path.sep`, thus adding the right path. This way, iOS projects can be linked from Windows also. 