### PR TITLE
Introduce prelink and postlink commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-rnpm link ![npm version](https://img.shields.io/npm/v/rnpm-plugin-link.svg) ![dependencies](https://img.shields.io/david/rnpm/rnpm-plugin-link.svg) [![Circle CI](https://img.shields.io/circleci/project/rnpm/rnpm-plugin-link/master.svg)](https://circleci.com/gh/rnpm/rnpm-plugin-link) 
+rnpm link ![npm version](https://img.shields.io/npm/v/rnpm-plugin-link.svg) ![dependencies](https://img.shields.io/david/rnpm/rnpm-plugin-link.svg) [![Circle CI](https://img.shields.io/circleci/project/rnpm/rnpm-plugin-link/master.svg)](https://circleci.com/gh/rnpm/rnpm-plugin-link)
 ==========
 
 This plugin is automatically installed with `rnpm`.
@@ -10,6 +10,11 @@ Automatically updates your project by linking all dependencies for Android (if p
 ```bash
 $ rnpm link react-native-module
 ```
+
+## Commands
+`rnpm-plugin-link` supports following commands:
+- `prelink` - runs before the link
+- `postlink` - runs after the link
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "mime": "^1.3.4",
     "npmlog": "^2.0.0",
     "plist": "^1.2.0",
-    "rnpm-hooks": "^1.1.0",
     "xcode": "^0.8.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mime": "^1.3.4",
     "npmlog": "^2.0.0",
     "plist": "^1.2.0",
+    "rnpm-hooks": "^1.1.0",
     "xcode": "^0.8.2"
   },
   "devDependencies": {

--- a/src/link.js
+++ b/src/link.js
@@ -1,8 +1,6 @@
-const spawn = require('child_process').spawn;
 const path = require('path');
 const log = require('npmlog');
 const uniq = require('lodash.uniq');
-const makeHook = require('rnpm-hooks');
 const async = require('async');
 
 const isEmpty = require('./isEmpty');
@@ -100,19 +98,19 @@ module.exports = function link(config, args, callback) {
     var prelink;
     var postlink;
 
-    if (dependency.config.hooks) {
-      prelink = dependency.config.hooks.prelink;
-      postlink = dependency.config.hooks.postlink;
+    if (dependency.config.commands) {
+      prelink = dependency.config.commands.prelink;
+      postlink = dependency.config.commands.postlink;
     }
 
     if (prelink) {
-      queue.push(makeHook(prelink));
+      queue.push(prelink);
     }
 
     queue.push(makeLink(dependency));
 
     if (postlink) {
-      queue.push(makeHook(postlink));
+      queue.push(postlink);
     }
 
     async.waterfall(queue, next);

--- a/src/link.js
+++ b/src/link.js
@@ -115,9 +115,7 @@ module.exports = function link(config, args, callback) {
       queue.push(makeHook(postlink));
     }
 
-    queue.push(next);
-
-    async.waterfall(queue);
+    async.waterfall(queue, next);
   });
 
   async.series(tasks, callback || () => {});

--- a/test/link.spec.js
+++ b/test/link.spec.js
@@ -85,6 +85,8 @@ describe('link', () => {
       registerNativeModule
     );
 
+    const link = require('../src/link');
+
     link(config, ['react-native-blur'], () => {
       expect(registerNativeModule.calledTwice).to.be.true;
     });

--- a/test/link.spec.js
+++ b/test/link.spec.js
@@ -34,7 +34,7 @@ describe('link', () => {
   it('should accept a name of a dependency to link', (done) => {
     const config = {
       getProjectConfig: () => ({ assets: [] }),
-      getDependencyConfig: sinon.stub().returns({ assets: [] }),
+      getDependencyConfig: sinon.stub().returns({ assets: [], commands: {} }),
     };
 
     link(config, ['react-native-gradient'], () => {
@@ -48,7 +48,7 @@ describe('link', () => {
   it('should read dependencies from package.json when name not provided', (done) => {
     const config = {
       getProjectConfig: () => ({ assets: [] }),
-      getDependencyConfig: sinon.stub().returns({ assets: [] }),
+      getDependencyConfig: sinon.stub().returns({ assets: [], commands: {} }),
     };
 
     mock(
@@ -72,7 +72,7 @@ describe('link', () => {
     const registerNativeModule = sinon.stub();
     const config = {
       getProjectConfig: () => ({ android: {}, ios: {}, assets: [] }),
-      getDependencyConfig: sinon.stub().returns({ android: {}, ios: {}, assets: [] }),
+      getDependencyConfig: sinon.stub().returns({ android: {}, ios: {}, assets: [], commands: {} }),
     };
 
     mock(
@@ -104,7 +104,7 @@ describe('link', () => {
 
     const config = {
       getProjectConfig: () => ({ ios: {}, assets: projectAssets }),
-      getDependencyConfig: sinon.stub().returns({ assets: dependencyAssets }),
+      getDependencyConfig: sinon.stub().returns({ assets: dependencyAssets, commands: {} }),
     };
 
     const link = require('../src/link');
@@ -130,7 +130,7 @@ describe('link', () => {
 
     const config = {
       getProjectConfig: () => ({ ios: {}, assets: projectAssets }),
-      getDependencyConfig: sinon.stub().returns({ assets: dependencyAssets }),
+      getDependencyConfig: sinon.stub().returns({ assets: dependencyAssets, commands: {} }),
     };
 
     const link = require('../src/link');


### PR DESCRIPTION
As we discussed in Discord, I've made a standalone repo for hooks wrapper.
Basically, since now, users can make their own plugins with a hooks support.

## How it works
Basically, I moved `makeHook` function to the standalone repo to allow other people use it.

## Scope of this PR
Replace in-place function by the `rnpm-hooks` module. Added missing `require` for testing and adjusted link code to take care about generating hooks. I'd like to keep `rnpm-hooks` as tiny as possible (and not to depend on our `dependency` object structure), so I think [this kind of logic](https://github.com/rnpm/rnpm-plugin-link/compare/chore/better-hooks?expand=1#diff-1dbe17fda47e0a0d65b16ad4646552d0R103) should be scoped in this specific plugin.

See [rnpm-hooks](https://github.com/rnpm/rnpm-hooks) for the further reading.