### PR TITLE
Fix wrong settings gradle patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "async": "^1.5.2",
     "fs-extra": "^0.26.2",
     "glob": "^6.0.1",
-    "lodash.difference": "^3.2.2",
+    "lodash.difference": "^4.0.1",
     "lodash.flowright": "^3.2.1",
     "lodash.groupby": "^4.0.0",
     "lodash.union": "^4.0.0",

--- a/src/android/patches/makeSettingsPatch.js
+++ b/src/android/patches/makeSettingsPatch.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = function makeSettingsPatch(name, dependencyConfig, projectConfig) {
   const relative = path.relative(
     projectConfig.sourceDir,
-    dependencyConfig.sourceDir
+    dependencyConfig.settingsGradlePath
   );
 
   /**

--- a/src/android/patches/makeSettingsPatch.js
+++ b/src/android/patches/makeSettingsPatch.js
@@ -2,8 +2,8 @@ const path = require('path');
 
 module.exports = function makeSettingsPatch(name, dependencyConfig, projectConfig) {
   const relative = path.relative(
-    projectConfig.sourceDir,
-    dependencyConfig.settingsGradlePath
+    path.dirname(projectConfig.settingsGradlePath),
+    dependencyConfig.sourceDir
   );
 
   /**

--- a/test/android/patches/makeSettingsPatch.spec.js
+++ b/test/android/patches/makeSettingsPatch.spec.js
@@ -5,8 +5,11 @@ const expect = chai.expect;
 const makeSettingsPatch = require('../../../src/android/patches/makeSettingsPatch');
 
 const name = 'test';
-const projectConfig = { sourceDir: '.' };
-const dependencyConfig = { sourceDir: `../node_modules/${name}/android` };
+const projectConfig = {
+  sourceDir: '/home/project/android/app',
+  settingsGradlePath: '/home/project/android/settings.gradle',
+};
+const dependencyConfig = { sourceDir: `/home/project/node_modules/${name}/android` };
 const settingsGradle = fs.readFileSync(
   path.join(process.cwd(), 'test/fixtures/android/settings.gradle'),
   'utf-8'
@@ -24,7 +27,7 @@ describe('makeSettingsPatch', () => {
   });
 
   it('should make a correct patch', () => {
-    const patch = makeSettingsPatch('test', dependencyConfig, projectConfig);
+    const patch = makeSettingsPatch(name, dependencyConfig, projectConfig);
     expect(patch(settingsGradle)).to.be.equal(patchedSettingsGradle);
   });
 });


### PR DESCRIPTION
settings.gradle is not always inside sourceDir, see -> https://github.com/rnpm/rnpm/blob/master/src/config/android/index.js#L41-L45. That PR changes the patch to always use `settings.gradle` real location (since we already expose it from rnpm config)