### PR TITLE
More foolproof way of checking plugin installation

### DIFF
--- a/src/android/registerNativeModule.js
+++ b/src/android/registerNativeModule.js
@@ -37,8 +37,8 @@ module.exports = function registerNativeAndroidModule(name, dependencyConfig, pr
    * Check if module has been installed already
    */
   const isInstalled = compose(
-    (content) => ~content.indexOf(dependencyConfig.packageInstance),
-    readFile(projectConfig.mainActivityPath)
+    (content) => ~content.indexOf(`:"${name}"`) || ~content.indexOf(`':${name}'`),
+    readFile(projectConfig.buildGradlePath)
   );
 
   if (!isInstalled(name)) {


### PR DESCRIPTION
Fixes https://github.com/rnpm/rnpm-plugin-link/issues/27.

The original way of checking for the presence of `new PackageClassName()` inside the MainActivity could fail in the following scenarios:

1. If the PackageClassName object requires extra parameters in construction, e.g `new PackageClassName(params...)`;
2. If the `PackageClassName` object is a private instance and not directly constructed, e.g. https://github.com/Microsoft/react-native-code-push/blob/master/Examples/CodePushDemoApp/android/app/src/main/java/com/microsoft/codepushdemoapp/MainActivity.java#L54

In general, looking into Java code to detect linkage is not foolproof because code is relatively non static and is always changed over the lifetime of a project.

This change proposes looking into the `build.gradle` file to detect linkage instead.