### PR TITLE
Make patch work on windows

### DIFF
--- a/src/android/patches/makeSettingsPatch.js
+++ b/src/android/patches/makeSettingsPatch.js
@@ -4,7 +4,7 @@ module.exports = function makeSettingsPatch(name, dependencyConfig, projectConfi
   const relative = path.relative(
     path.dirname(projectConfig.settingsGradlePath),
     dependencyConfig.sourceDir
-  );
+  ).replace(/\\/g, '/');
 
   /**
    * Replace pattern by patch in the passed content


### PR DESCRIPTION
path.sep on windows is `\`, breaking the path in settings.gradle. The fix is to either duplicate it as in `..\\some\\path` or replace it with `/` which still works on windows.

fixes rnpm/rnpm-plugin-link#36