### PR TITLE
Add 0.20 patch for Android

### DIFF
--- a/src/android/getPrefix.js
+++ b/src/android/getPrefix.js
@@ -1,12 +1,16 @@
 const semver = require('semver');
+const versions = ['0.20', '0.18', '0.17'];
 
 module.exports = function getPrefix(rnVersion) {
   const version = rnVersion.replace('-rc', '');
-  var prefix = 'patches/0.18';
+  var prefix = 'patches/0.20';
 
-  if (semver.lt(version, '0.18.0')) {
-    prefix = 'patches/0.17';
-  }
+  versions.forEach((item, i) => {
+    const nextVersion = versions[i + 1];
+    if (semver.lt(version, item + '.0') && nextVersion) {
+      prefix = `patches/${nextVersion}`;
+    }
+  });
 
   return prefix;
 };

--- a/src/android/patches/0.20/addPackagePatch.js
+++ b/src/android/patches/0.20/addPackagePatch.js
@@ -1,0 +1,2 @@
+module.exports = (config) =>
+  ',\n            ' + config.packageInstance;

--- a/src/android/patches/0.20/makeMainActivityPatch.js
+++ b/src/android/patches/0.20/makeMainActivityPatch.js
@@ -1,0 +1,29 @@
+const addPackagePatch = require('./addPackagePatch');
+
+const append = (scope, pattern, patch) =>
+  scope.replace(pattern, `${pattern}${patch}`);
+
+module.exports = function makeMainActivityPatch(config) {
+  const importPattern = 'import com.facebook.react.ReactActivity;';
+  const packagePattern = 'new MainReactPackage()';
+
+  /**
+   * Make a MainActivity.java program patcher
+   * @param  {String}   importPath Import path, e.g. com.oblador.vectoricons.VectorIconsPackage;
+   * @param  {String}   instance   Code to instance a package, e.g. new VectorIconsPackage();
+   * @return {Function}            Patcher function
+   */
+  return function applyMainActivityPatch(content) {
+    const patched = append(
+      content,
+      importPattern,
+      '\n' + config.packageImportPath
+    );
+
+    return append(
+      patched,
+      packagePattern,
+      addPackagePatch(config)
+    );
+  };
+};


### PR DESCRIPTION
1. The MainActivity.java have a small change in RN 0.20 (see https://github.com/facebook/react-native/commit/abdca047b0d3a1f9627a485c15fad0b99c5c241e).
2. Let android/getPrefix.js support multi versions.