### PR TITLE
Replace Path backslashes in makeSettingsPatch on Windows

### DIFF
--- a/src/android/patches/makeSettingsPatch.js
+++ b/src/android/patches/makeSettingsPatch.js
@@ -6,6 +6,13 @@ module.exports = function makeSettingsPatch(name, dependencyConfig, projectConfi
     dependencyConfig.sourceDir
   );
 
+  /*
+   * Fix for Windows
+   * Backslashes is the escape character and will result in an invalid path in settings.gradle
+   * https://github.com/rnpm/rnpm/issues/113
+   */
+  const relativePlatform = process.platform === 'win32' ? relative.replace(/\\/g, '/') : relative;
+
   /**
    * Replace pattern by patch in the passed content
    * @param  {String} content Content of the Settings.gradle file
@@ -14,7 +21,7 @@ module.exports = function makeSettingsPatch(name, dependencyConfig, projectConfi
   return function applySettingsPatch(content) {
     const patch = `include ':${name}'\n` +
       `project(':${name}').projectDir = ` +
-      `new File(rootProject.projectDir, '${relative}')`;
+      `new File(rootProject.projectDir, '${relativePlatform}')`;
 
     return `${content.trim()}\n${patch}\n`;
   };


### PR DESCRIPTION
Fixes https://github.com/rnpm/rnpm/issues/113

Builds on and replaces https://github.com/rnpm/rnpm-plugin-link/pull/36 that seems abandoned