### PR TITLE
Android: isInstalled fails for package entries with double quotes

### DIFF
--- a/src/android/registerNativeModule.js
+++ b/src/android/registerNativeModule.js
@@ -37,7 +37,7 @@ module.exports = function registerNativeAndroidModule(name, dependencyConfig, pr
    * Check if module has been installed already
    */
   const isInstalled = compose(
-    (content) => ~content.indexOf(`:"${name}"`) || ~content.indexOf(`':${name}'`),
+    (content) => ~content.indexOf(`":${name}"`) || ~content.indexOf(`':${name}'`),
     readFile(projectConfig.buildGradlePath)
   );
 


### PR DESCRIPTION
The `.indexOf` pattern was wrong: the colon was outside the quotes