### PR TITLE
Handle nested groups

### DIFF
--- a/src/ios/createGroup.js
+++ b/src/ios/createGroup.js
@@ -3,9 +3,8 @@ const getGroup = require('./getGroup');
 const hasGroup = (pbxGroup, name) => pbxGroup.children.find(group => group.comment === name);
 
 /**
- * Given project and name of the group, creates a new top-level group,
- * that is then - added to `mainGroup` so that it's visible as a top-level
- * folder in your Xcode sidebar
+ * Given project and path of the group, it deeply creates a given group
+ * making all outer groups if neccessary
  *
  * Returns newly created group
  */

--- a/src/ios/createGroup.js
+++ b/src/ios/createGroup.js
@@ -1,4 +1,6 @@
-const getFirstProject = (project) => project.getFirstProject().firstProject;
+const getGroup = require('./getGroup');
+
+const hasGroup = (pbxGroup, name) => pbxGroup.children.find(group => group.comment === name);
 
 /**
  * Given project and name of the group, creates a new top-level group,
@@ -7,21 +9,20 @@ const getFirstProject = (project) => project.getFirstProject().firstProject;
  *
  * Returns newly created group
  */
-module.exports = function createGroup(project, name) {
-  const uuid = project.pbxCreateGroup(name, '""');
+module.exports = function createGroup(project, path) {
+  return path.split('/').reduce(
+    (group, name) => {
+      if (!hasGroup(group, name)) {
+        const uuid = project.pbxCreateGroup(name, '""');
 
-  const firstProject = getFirstProject(project);
+        group.children.push({
+          value: uuid,
+          comment: name,
+        });
+      }
 
-  project
-    .getPBXGroupByKey(firstProject.mainGroup)
-    .children
-    .push({
-      value: uuid,
-      comment: name,
-    });
-
-  return {
-    group: project.pbxGroupByName(name),
-    uuid,
-  };
+      return project.pbxGroupByName(name);
+    },
+    getGroup(project)
+  );
 };

--- a/src/ios/getGroup.js
+++ b/src/ios/getGroup.js
@@ -1,0 +1,29 @@
+const getFirstProject = (project) => project.getFirstProject().firstProject;
+
+const findGroup = (group, name) => group.children.find(group => group.comment === name);
+
+/**
+ * Returns group from .xcodeproj if one exists, null otherwise
+ *
+ * Unlike node-xcode `pbxGroupByName` - it does not return `first-matching`
+ * group if multiple groups with the same name exist
+ */
+module.exports = function getGroup(project, path) {
+  const firstProject = getFirstProject(project);
+  const names = path.split('/');
+
+  var group = project.getPBXGroupByKey(firstProject.mainGroup);
+
+  for (var name of names) {
+    var foundGroup = findGroup(group, name);
+
+    if (foundGroup) {
+      group = project.getPBXGroupByKey(foundGroup.value);
+    } else {
+      group = null;
+      break;
+    }
+  }
+
+  return group;
+};

--- a/src/ios/getGroup.js
+++ b/src/ios/getGroup.js
@@ -7,14 +7,19 @@ const findGroup = (group, name) => group.children.find(group => group.comment ==
  *
  * Unlike node-xcode `pbxGroupByName` - it does not return `first-matching`
  * group if multiple groups with the same name exist
+ *
+ * If path is not provided, it returns top-level group
  */
 module.exports = function getGroup(project, path) {
   const firstProject = getFirstProject(project);
-  const names = path.split('/');
 
   var group = project.getPBXGroupByKey(firstProject.mainGroup);
 
-  for (var name of names) {
+  if (!path) {
+    return group;
+  }
+
+  for (var name of path.split('/')) {
     var foundGroup = findGroup(group, name);
 
     if (foundGroup) {

--- a/src/ios/registerNativeModule.js
+++ b/src/ios/registerNativeModule.js
@@ -29,7 +29,7 @@ module.exports = function registerNativeModuleIOS(dependencyConfig, projectConfi
   var libraries = getGroup(project, projectConfig.libraryFolder);
 
   if (!libraries) {
-    libraries = createGroup(project, projectConfig.libraryFolder).group;
+    libraries = createGroup(project, projectConfig.libraryFolder);
 
     log.warn(
       'ERRGROUP',

--- a/src/ios/registerNativeModule.js
+++ b/src/ios/registerNativeModule.js
@@ -13,6 +13,7 @@ const addFileToProject = require('./addFileToProject');
 const addProjectToLibraries = require('./addProjectToLibraries');
 const addSharedLibraries = require('./addSharedLibraries');
 const isEmpty = require('lodash').isEmpty;
+const getGroup = require('./getGroup');
 
 /**
  * Register native module IOS adds given dependency to project by adding
@@ -25,7 +26,7 @@ module.exports = function registerNativeModuleIOS(dependencyConfig, projectConfi
   const project = xcode.project(projectConfig.pbxprojPath).parseSync();
   const dependencyProject = xcode.project(dependencyConfig.pbxprojPath).parseSync();
 
-  var libraries = project.pbxGroupByName(projectConfig.libraryFolder);
+  var libraries = getGroup(project, projectConfig.libraryFolder);
 
   if (!libraries) {
     libraries = createGroup(project, projectConfig.libraryFolder).group;

--- a/src/ios/unlinkAssets.js
+++ b/src/ios/unlinkAssets.js
@@ -4,7 +4,6 @@ const xcode = require('xcode');
 const log = require('npmlog');
 const plistParser = require('plist');
 const groupFilesByType = require('../groupFilesByType');
-const createGroup = require('./createGroup');
 const getPlist = require('./getPlist');
 const difference = require('lodash').difference;
 

--- a/src/ios/unregisterNativeModule.js
+++ b/src/ios/unregisterNativeModule.js
@@ -12,6 +12,7 @@ const removeProjectFromLibraries = require('./removeProjectFromLibraries');
 const removeFromStaticLibraries = require('./removeFromStaticLibraries');
 const removeFromHeaderSearchPaths = require('./removeFromHeaderSearchPaths');
 const removeSharedLibraries = require('./addSharedLibraries');
+const getGroup = require('./getGroup');
 
 /**
  * Unregister native module IOS
@@ -22,7 +23,7 @@ module.exports = function unregisterNativeModule(dependencyConfig, projectConfig
   const project = xcode.project(projectConfig.pbxprojPath).parseSync();
   const dependencyProject = xcode.project(dependencyConfig.pbxprojPath).parseSync();
 
-  const libraries = project.pbxGroupByName(projectConfig.libraryFolder);
+  const libraries = getGroup(project, projectConfig.libraryFolder);
   if (!libraries || !hasLibraryImported(libraries, dependencyConfig.projectName)) {
     return false;
   }

--- a/test/fixtures/project.pbxproj
+++ b/test/fixtures/project.pbxproj
@@ -105,17 +105,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = main.jsbundle; path = main.jsbundle; sourceTree = "<group>"; };
-		00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTActionSheet.xcodeproj; path = ../node_modules/react-native/Libraries/ActionSheetIOS/RCTActionSheet.xcodeproj; sourceTree = "<group>"; };
-		00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTGeolocation.xcodeproj; path = ../node_modules/react-native/Libraries/Geolocation/RCTGeolocation.xcodeproj; sourceTree = "<group>"; };
-		00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTImage.xcodeproj; path = ../node_modules/react-native/Libraries/Image/RCTImage.xcodeproj; sourceTree = "<group>"; };
-		00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTNetwork.xcodeproj; path = ../node_modules/react-native/Libraries/Network/RCTNetwork.xcodeproj; sourceTree = "<group>"; };
-		00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTVibration.xcodeproj; path = ../node_modules/react-native/Libraries/Vibration/RCTVibration.xcodeproj; sourceTree = "<group>"; };
+		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
+		00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTActionSheet.xcodeproj; path = "../node_modules/react-native/Libraries/ActionSheetIOS/RCTActionSheet.xcodeproj"; sourceTree = "<group>"; };
+		00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTGeolocation.xcodeproj; path = "../node_modules/react-native/Libraries/Geolocation/RCTGeolocation.xcodeproj"; sourceTree = "<group>"; };
+		00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTImage.xcodeproj; path = "../node_modules/react-native/Libraries/Image/RCTImage.xcodeproj"; sourceTree = "<group>"; };
+		00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTNetwork.xcodeproj; path = "../node_modules/react-native/Libraries/Network/RCTNetwork.xcodeproj"; sourceTree = "<group>"; };
+		00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTVibration.xcodeproj; path = "../node_modules/react-native/Libraries/Vibration/RCTVibration.xcodeproj"; sourceTree = "<group>"; };
 		00E356EE1AD99517003FC87E /* BasicTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BasicTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* BasicTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BasicTests.m; sourceTree = "<group>"; };
-		139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTSettings.xcodeproj; path = ../node_modules/react-native/Libraries/Settings/RCTSettings.xcodeproj; sourceTree = "<group>"; };
-		139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTWebSocket.xcodeproj; path = ../node_modules/react-native/Libraries/WebSocket/RCTWebSocket.xcodeproj; sourceTree = "<group>"; };
+		139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTSettings.xcodeproj; path = "../node_modules/react-native/Libraries/Settings/RCTSettings.xcodeproj"; sourceTree = "<group>"; };
+		139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTWebSocket.xcodeproj; path = "../node_modules/react-native/Libraries/WebSocket/RCTWebSocket.xcodeproj"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* Basic.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Basic.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = Basic/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = Basic/AppDelegate.m; sourceTree = "<group>"; };
@@ -123,9 +123,9 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Basic/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Basic/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Basic/main.m; sourceTree = "<group>"; };
-		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = ../node_modules/react-native/React/React.xcodeproj; sourceTree = "<group>"; };
-		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = ../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj; sourceTree = "<group>"; };
-		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = ../node_modules/react-native/Libraries/Text/RCTText.xcodeproj; sourceTree = "<group>"; };
+		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
+		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
+		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -287,6 +287,7 @@
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
+				AD9196DA1CABA83E000E8D91 /* NestedGroup */,
 				13B07FAE1A68108700A75B9A /* Basic */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				00E356EF1AD99517003FC87E /* BasicTests */,
@@ -303,6 +304,21 @@
 				00E356EE1AD99517003FC87E /* BasicTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		AD9196DA1CABA83E000E8D91 /* NestedGroup */ = {
+			isa = PBXGroup;
+			children = (
+				AD9196DB1CABA844000E8D91 /* Libraries */,
+			);
+			name = NestedGroup;
+			sourceTree = "<group>";
+		};
+		AD9196DB1CABA844000E8D91 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -359,7 +375,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "Basic" */;
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "a" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -526,7 +542,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "../node_modules/react-native/packager/react-native-xcode.sh";
-			showEnvVarsInLog = 1;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -748,7 +763,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "Basic" */ = {
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "a" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				83CBBA201A601CBA00E9B192 /* Debug */,

--- a/test/ios/createGroup.spec.js
+++ b/test/ios/createGroup.spec.js
@@ -27,4 +27,11 @@ describe('ios::createGroup', () => {
     ).to.equals(createdGroup.uuid);
   });
 
+  it.skip('should create a nested group with given path', () => {
+    const createdGroup = createGroup(project, 'NewGroup/NewNestedGroup').group;
+  });
+
+  it.skip('should-not create already created groups', () => {
+    const createdGroup = createGroup(project, 'Libraries/NewNestedGroup').group;
+  });
 });

--- a/test/ios/createGroup.spec.js
+++ b/test/ios/createGroup.spec.js
@@ -44,8 +44,6 @@ describe('ios::createGroup', () => {
     expect(
       mainGroup.children.filter(group => group.comment === 'Libraries').length
     ).to.equals(1);
-    expect(
-      last(outerGroup.children).comment
-    ).to.equals(createdGroup.name);
+    expect(last(outerGroup.children).comment).to.equals(createdGroup.name);
   });
 });

--- a/test/ios/createGroup.spec.js
+++ b/test/ios/createGroup.spec.js
@@ -2,6 +2,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const xcode = require('xcode');
 const createGroup = require('../../src/ios/createGroup');
+const getGroup = require('../../src/ios/getGroup');
 const last = require('lodash').last;
 
 const project = xcode.project('test/fixtures/project.pbxproj');
@@ -13,25 +14,34 @@ describe('ios::createGroup', () => {
   });
 
   it('should create a group with given name', () => {
-    const createdGroup = createGroup(project, 'Resources').group;
+    const createdGroup = createGroup(project, 'Resources');
     expect(createdGroup.name).to.equals('Resources');
   });
 
   it('should attach group to main project group', () => {
-    const mainGroupId = project.getFirstProject().firstProject.mainGroup;
     const createdGroup = createGroup(project, 'Resources');
-    const mainGroup = project.getPBXGroupByKey(mainGroupId);
+    const mainGroup = getGroup(project);
 
     expect(
-      last(mainGroup.children).value
-    ).to.equals(createdGroup.uuid);
+      last(mainGroup.children).comment
+    ).to.equals(createdGroup.name);
   });
 
-  it.skip('should create a nested group with given path', () => {
-    const createdGroup = createGroup(project, 'NewGroup/NewNestedGroup').group;
+  it('should create a nested group with given path', () => {
+    const createdGroup = createGroup(project, 'NewGroup/NewNestedGroup');
+    const outerGroup = getGroup(project, 'NewGroup');
+
+    expect(
+      last(outerGroup.children).comment
+    ).to.equals(createdGroup.name);
   });
 
-  it.skip('should-not create already created groups', () => {
+  it('should-not create already created groups', () => {
     const createdGroup = createGroup(project, 'Libraries/NewNestedGroup').group;
+    const mainGroup = getGroup(project);
+
+    expect(
+      mainGroup.children.filter(group => group.comment === 'Libraries').length
+    ).to.equals(1);
   });
 });

--- a/test/ios/createGroup.spec.js
+++ b/test/ios/createGroup.spec.js
@@ -37,11 +37,15 @@ describe('ios::createGroup', () => {
   });
 
   it('should-not create already created groups', () => {
-    const createdGroup = createGroup(project, 'Libraries/NewNestedGroup').group;
+    const createdGroup = createGroup(project, 'Libraries/NewNestedGroup');
+    const outerGroup = getGroup(project, 'Libraries');
     const mainGroup = getGroup(project);
 
     expect(
       mainGroup.children.filter(group => group.comment === 'Libraries').length
     ).to.equals(1);
+    expect(
+      last(outerGroup.children).comment
+    ).to.equals(createdGroup.name);
   });
 });

--- a/test/ios/getGroup.spec.js
+++ b/test/ios/getGroup.spec.js
@@ -12,13 +12,18 @@ describe('ios::getGroup', () => {
 
   it('should return a top-level group', () => {
     const group = getGroup(project, 'Libraries');
-    expect(group.children.length > 0).to.be.true;
+    expect(group.children.length > 0).to.be.true; // our test top-level Libraries has children
     expect(group.name).to.equals('Libraries');
   });
 
   it('should return nested group when specified', () => {
     const group = getGroup(project, 'NestedGroup/Libraries');
-    expect(group.children.length).to.equals(0);
+    expect(group.children.length).to.equals(0); // our test nested Libraries is empty
     expect(group.name).to.equals('Libraries');
+  });
+
+  it('should return null when no group found', () => {
+    const group = getGroup(project, 'I-Dont-Exist');
+    expect(group).to.be.null;
   });
 });

--- a/test/ios/getGroup.spec.js
+++ b/test/ios/getGroup.spec.js
@@ -1,0 +1,24 @@
+const chai = require('chai');
+const expect = chai.expect;
+const xcode = require('xcode');
+const getGroup = require('../../src/ios/getGroup');
+
+const project = xcode.project('test/fixtures/project.pbxproj');
+
+describe('ios::getGroup', () => {
+  beforeEach(() => {
+    project.parseSync();
+  });
+
+  it('should return a top-level group', () => {
+    const group = getGroup(project, 'Libraries');
+    expect(group.children.length > 0).to.be.true;
+    expect(group.name).to.equals('Libraries');
+  });
+
+  it('should return nested group when specified', () => {
+    const group = getGroup(project, 'NestedGroup/Libraries');
+    expect(group.children.length).to.equals(0);
+    expect(group.name).to.equals('Libraries');
+  });
+});

--- a/test/ios/getGroup.spec.js
+++ b/test/ios/getGroup.spec.js
@@ -26,4 +26,11 @@ describe('ios::getGroup', () => {
     const group = getGroup(project, 'I-Dont-Exist');
     expect(group).to.be.null;
   });
+
+  it('should return top-level group when name not specified', () => {
+    const mainGroupId = project.getFirstProject().firstProject.mainGroup;
+    const mainGroup = project.getPBXGroupByKey(mainGroupId);
+    const group = getGroup(project);
+    expect(group).to.equals(mainGroup);
+  });
 });


### PR DESCRIPTION
What this PR does:

- You can specify nested `libraryFolder`, see my comment below,
- When you have multiple groups with the same name, we no longer pick the wrong one, see: https://github.com/rnpm/rnpm/issues/111#issuecomment-202984773

Technical explanation:
Problem is - `pbxGroupByName` will return first matching group by name (regardless of nesting level). We loop recursively over all groups with our new function and also support paths, e.g. `NestedGroup/Libraries`, so if you would prefer to use libraries group that's not top-level, you can easily override that.

That PR also implements the above for `createGroup`.