### PR TITLE
getPlistPath return value fix

### DIFF
--- a/src/ios/getPlistPath.js
+++ b/src/ios/getPlistPath.js
@@ -8,7 +8,7 @@ module.exports = function getPlistPath(project, sourceDir) {
     return null;
   }
 
-  const plistPath = path.join(
+  return path.join(
     sourceDir,
     plistFile.replace(/"/g, '').replace('$(SRCROOT)', '')
   );


### PR DESCRIPTION
This PR fixes getPlistPath return value, at current version it returns null or undefined