### PR TITLE
Fix error when RN version is x.x.x-rc1

### DIFF
--- a/src/android/getPrefix.js
+++ b/src/android/getPrefix.js
@@ -2,7 +2,7 @@ const semver = require('semver');
 const versions = ['0.20', '0.18', '0.17'];
 
 module.exports = function getPrefix(rnVersion) {
-  const version = rnVersion.substring(0, rnVersion.substring('-'));
+  const version = rnVersion.substring(0, rnVersion.indexOf('-'));
   var prefix = 'patches/0.20';
 
   versions.forEach((item, i) => {

--- a/src/android/getPrefix.js
+++ b/src/android/getPrefix.js
@@ -2,7 +2,7 @@ const semver = require('semver');
 const versions = ['0.20', '0.18', '0.17'];
 
 module.exports = function getPrefix(rnVersion) {
-  const version = ~rnVersion.indexOf('-') ? rnVersion.substring(0, rnVersion.indexOf('-')) : rnVersion;
+  const version = rnVersion.replace(/-.*/, '');
   var prefix = 'patches/0.20';
 
   versions.forEach((item, i) => {

--- a/src/android/getPrefix.js
+++ b/src/android/getPrefix.js
@@ -2,7 +2,7 @@ const semver = require('semver');
 const versions = ['0.20', '0.18', '0.17'];
 
 module.exports = function getPrefix(rnVersion) {
-  const version = rnVersion.substring(0, rnVersion.indexOf('-'));
+  const version = ~rnVersion.indexOf('-') ? rnVersion.substring(0, rnVersion.indexOf('-')) : rnVersion;
   var prefix = 'patches/0.20';
 
   versions.forEach((item, i) => {

--- a/src/android/getPrefix.js
+++ b/src/android/getPrefix.js
@@ -2,7 +2,7 @@ const semver = require('semver');
 const versions = ['0.20', '0.18', '0.17'];
 
 module.exports = function getPrefix(rnVersion) {
-  const version = rnVersion.replace('-rc', '');
+  const version = rnVersion.substring(0, rnVersion.substring('-'));
   var prefix = 'patches/0.20';
 
   versions.forEach((item, i) => {

--- a/test/getPrefix.spec.js
+++ b/test/getPrefix.spec.js
@@ -7,13 +7,14 @@ const oldPrefix = 'patches/0.17';
 describe('getPrefix', () => {
   it('require a specific patch for react-native < 0.18', () => {
     expect(getMainActivityPatch('0.17.0-rc')).to.equals(oldPrefix);
+    expect(getMainActivityPatch('0.17.1-rc2')).to.equals(oldPrefix);
     expect(getMainActivityPatch('0.17.2')).to.equals(oldPrefix);
   });
 
   it('require a specific patch for react-native > 0.18', () => {
     expect(getMainActivityPatch('0.19.0')).to.equals(newPrefix);
     expect(getMainActivityPatch('0.19.0-rc')).to.equals(newPrefix);
-    expect(getMainActivityPatch('0.18.0-rc')).to.equals(newPrefix);
+    expect(getMainActivityPatch('0.18.0-rc1')).to.equals(newPrefix);
     expect(getMainActivityPatch('0.18.2')).to.equals(newPrefix);
   });
 });


### PR DESCRIPTION
Currently:
```javascript
let rnVersion = '0.24.0-rc1';
const version = rnVersion.replace('-rc', ''); // becomes '0.24.01'
...
     if (semver.lt(version, item + '.0') && nextVersion) // throws exception since version is not valid semver
```

Fixed this, and also updated the unit tests.