### PR TITLE
Fix for prelink/postlink commands not being called

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -16,7 +16,7 @@ log.heading = 'rnpm-link';
 const commandStub = (cb) => cb();
 const dedupeAssets = (assets) => uniq(assets, asset => path.basename(asset));
 
-const promisify = (func) => () => new Promise((resolve, reject) =>
+const promisify = (func) => new Promise((resolve, reject) =>
   func((err, res) => err ? reject(err) : resolve(res))
 );
 


### PR DESCRIPTION
The `promisify` helper went too deep with the arrow functions. Added a test to ensure these commands are called in the right order.

Fixes #64