### PR TITLE
Update `unlink` interface

### DIFF
--- a/src/android/registerNativeModule.js
+++ b/src/android/registerNativeModule.js
@@ -35,6 +35,4 @@ module.exports = function registerNativeAndroidModule(
     projectConfig.mainActivityPath,
     makeImportPatch(androidConfig.packageImportPath)
   );
-
-  return true;
 };

--- a/src/android/unregisterNativeModule.js
+++ b/src/android/unregisterNativeModule.js
@@ -44,6 +44,4 @@ module.exports = function unregisterNativeAndroidModule(
     projectConfig.mainActivityPath,
     makeImportPatch(androidConfig.packageImportPath)
   );
-
-  return true;
 };

--- a/src/ios/unregisterNativeModule.js
+++ b/src/ios/unregisterNativeModule.js
@@ -6,7 +6,6 @@ const getProducts = require('./getProducts');
 const getHeadersInFolder = require('./getHeadersInFolder');
 const isEmpty = require('lodash').isEmpty;
 const getHeaderSearchPath = require('./getHeaderSearchPath');
-const hasLibraryImported = require('./hasLibraryImported');
 const removeProjectFromProject = require('./removeProjectFromProject');
 const removeProjectFromLibraries = require('./removeProjectFromLibraries');
 const removeFromStaticLibraries = require('./removeFromStaticLibraries');
@@ -24,9 +23,6 @@ module.exports = function unregisterNativeModule(dependencyConfig, projectConfig
   const dependencyProject = xcode.project(dependencyConfig.pbxprojPath).parseSync();
 
   const libraries = getGroup(project, projectConfig.libraryFolder);
-  if (!libraries || !hasLibraryImported(libraries, dependencyConfig.projectName)) {
-    return false;
-  }
 
   const file = removeProjectFromProject(
     project,
@@ -55,6 +51,4 @@ module.exports = function unregisterNativeModule(dependencyConfig, projectConfig
     projectConfig.pbxprojPath,
     project.writeSync()
   );
-
-  return true;
 };

--- a/src/unlink.js
+++ b/src/unlink.js
@@ -23,7 +23,7 @@ const unlinkDependencyAndroid = (androidProject, dependency, packageName) => {
   const isInstalled = isInstalledAndroid(androidProject, packageName);
 
   if (!isInstalled) {
-    log.info(`Android module ${packageName} is already unlinked`);
+    log.info(`Android module ${packageName} is not installed`);
     return;
   }
 
@@ -42,7 +42,7 @@ const unlinkDependencyIOS = (iOSProject, dependency, packageName) => {
   const isInstalled = isInstalledIOS(iOSProject, dependency.ios);
 
   if (!isInstalled) {
-    log.info(`iOS module ${packageName} is already unlinked`);
+    log.info(`iOS module ${packageName} is not installed`);
     return;
   }
 

--- a/src/unlink.js
+++ b/src/unlink.js
@@ -4,6 +4,8 @@ const log = require('npmlog');
 const getProjectDependencies = require('./getProjectDependencies');
 const unregisterDependencyAndroid = require('./android/unregisterNativeModule');
 const unregisterDependencyIOS = require('./ios/unregisterNativeModule');
+const isInstalledAndroid = require('./android/isInstalled');
+const isInstalledIOS = require('./ios/isInstalled');
 const unlinkAssetsAndroid = require('./android/unlinkAssets');
 const unlinkAssetsIOS = require('./ios/unlinkAssets');
 const getDependencyConfig = require('./getDependencyConfig');
@@ -13,14 +15,57 @@ const flatten = require('lodash').flatten;
 
 log.heading = 'rnpm-link';
 
+const unlinkDependencyAndroid = (androidProject, dependency, packageName) => {
+  if (!androidProject || !dependency.android) {
+    return;
+  }
+
+  const isInstalled = isInstalledAndroid(androidProject, packageName);
+
+  if (!isInstalled) {
+    log.info(`Android module ${packageName} is already unlinked`);
+    return;
+  }
+
+  log.info(`Unlinking ${packageName} android dependency`);
+
+  unregisterDependencyAndroid(packageName, dependency.android, androidProject);
+
+  log.info(`Android module ${packageName} has been successfully unlinked`);
+};
+
+const unlinkDependencyIOS = (iOSProject, dependency, packageName) => {
+  if (!iOSProject || !dependency.ios) {
+    return;
+  }
+
+  const isInstalled = isInstalledIOS(iOSProject, dependency.ios);
+
+  if (!isInstalled) {
+    log.info(`iOS module ${packageName} is already unlinked`);
+    return;
+  }
+
+  log.info(`Unlinking ${packageName} ios dependency`);
+
+  unregisterDependencyIOS(dependency.ios, project.ios);
+
+  log.info(`iOS module ${packageName} has been successfully unlinked`);
+};
+
 /**
  * Updates project and unlink specific dependency
  *
  * If optional argument [packageName] is provided, it's the only one that's checked
  */
 module.exports = function unlink(config, args) {
+  const packageName = args[0];
+
+  var project;
+  var dependency;
+
   try {
-    const project = config.getProjectConfig();
+    project = config.getProjectConfig();
   } catch (err) {
     log.error(
       'ERRPACKAGEJSON',
@@ -29,47 +74,17 @@ module.exports = function unlink(config, args) {
     return Promise.reject(err);
   }
 
-  const packageName = args[0];
-
   try {
-    const dependency = config.getDependencyConfig(packageName);
+    dependency = config.getDependencyConfig(packageName);
   } catch (err) {
-    log.warn(
-      'ERRINVALIDPROJ',
-      `Project ${packageName} is not a react-native library`
-    );
+    log.warn('ERRINVALIDPROJ', `Project ${packageName} is not a react-native library`);
     return Promise.reject(err);
   }
 
+  unlinkDependencyAndroid(project.ios, dependency, packageName);
+  unlinkDependencyIOS(project.ios, dependency, packageName);
+
   const allDependencies = getDependencyConfig(config, getProjectDependencies());
-
-  if (project.android && dependency.android) {
-    log.info(`Unlinking ${packageName} android dependency`);
-
-    const didUnlinkAndroid = unregisterDependencyAndroid(
-      packageName,
-      dependency.android,
-      project.android
-    );
-
-    if (didUnlinkAndroid) {
-      log.info(`Android module ${packageName} has been successfully unlinked`);
-    } else {
-      log.info(`Android module ${packageName} is not linked yet`);
-    }
-  }
-
-  if (project.ios && dependency.ios) {
-    log.info(`Unlinking ${packageName} ios dependency`);
-
-    const didUnlinkIOS = unregisterDependencyIOS(dependency.ios, project.ios);
-
-    if (didUnlinkIOS) {
-      log.info(`iOS module ${packageName} has been successfully unlinked`);
-    } else {
-      log.info(`iOS module ${packageName} is not linked yet`);
-    }
-  }
 
   const assets = difference(
     dependency.assets,

--- a/src/unlink.js
+++ b/src/unlink.js
@@ -56,7 +56,8 @@ const unlinkDependencyIOS = (iOSProject, dependency, packageName) => {
 /**
  * Updates project and unlink specific dependency
  *
- * If optional argument [packageName] is provided, it's the only one that's checked
+ * If optional argument [packageName] is provided, it's the only one
+ * that's checked
  */
 module.exports = function unlink(config, args) {
   const packageName = args[0];
@@ -77,7 +78,10 @@ module.exports = function unlink(config, args) {
   try {
     dependency = config.getDependencyConfig(packageName);
   } catch (err) {
-    log.warn('ERRINVALIDPROJ', `Project ${packageName} is not a react-native library`);
+    log.warn(
+      'ERRINVALIDPROJ',
+      `Project ${packageName} is not a react-native library`
+    );
     return Promise.reject(err);
   }
 
@@ -105,7 +109,9 @@ module.exports = function unlink(config, args) {
     unlinkAssetsAndroid(assets, project.android.assetsPath);
   }
 
-  log.info(`${packageName} assets has been successfully unlinked from your project`);
+  log.info(
+    `${packageName} assets has been successfully unlinked from your project`
+  );
 
   return Promise.resolve();
 };

--- a/src/unlink.js
+++ b/src/unlink.js
@@ -48,7 +48,7 @@ const unlinkDependencyIOS = (iOSProject, dependency, packageName) => {
 
   log.info(`Unlinking ${packageName} ios dependency`);
 
-  unregisterDependencyIOS(dependency.ios, project.ios);
+  unregisterDependencyIOS(dependency.ios, iOSProject);
 
   log.info(`iOS module ${packageName} has been successfully unlinked`);
 };
@@ -81,7 +81,7 @@ module.exports = function unlink(config, args) {
     return Promise.reject(err);
   }
 
-  unlinkDependencyAndroid(project.ios, dependency, packageName);
+  unlinkDependencyAndroid(project.android, dependency, packageName);
   unlinkDependencyIOS(project.ios, dependency, packageName);
 
   const allDependencies = getDependencyConfig(config, getProjectDependencies());


### PR DESCRIPTION
Scope:
1) Remove `return` value from `registerDependencyAndroid` as these functions should not have return value
2) Remove `isInstalled` checks and return values from `unregister` versions as these functions should not have return value and the check is done separately
3) Add `isInstalled` check inside `unlink`
4) Fix scope in try-catch block for ES6 compatibility 

This PR is important to ship as it looks like https://github.com/rnpm/rnpm-plugin-link/pull/70/files#diff-7c8e252a3de28dabaaf67dd7fdf34a29L64 already did point 2 for `android`. That means on Android, we do not check if dependency is installed before linking.