### PR TITLE
Improve build.gradle patch

### DIFF
--- a/src/android/patches/applyPatch.js
+++ b/src/android/patches/applyPatch.js
@@ -3,6 +3,6 @@ const fs = require('fs');
 module.exports = function applyPatch(file, patch) {
   fs.writeFileSync(file, fs
     .readFileSync(file, 'utf8')
-    .replace(patch.pattern, `${patch.pattern}${patch.patch}`)
+    .replace(patch.pattern, match => `${match}${patch.patch}`)
   );
 };

--- a/src/android/patches/makeBuildPatch.js
+++ b/src/android/patches/makeBuildPatch.js
@@ -1,6 +1,6 @@
 module.exports = function makeBuildPatch(name) {
   return {
-    pattern: 'dependencies {\n',
+    pattern: /[^ \t]dependencies {\n/,
     patch: `    compile project(':${name}')\n`,
   };
 };


### PR DESCRIPTION
Fixes #75 

This PR originally just added a regexp pattern (see `makeBuildPatch`). It won't pick any `dependencies {` block if it's starting with a space or a tab (handles nesting).

However, I had to modify the way we apply patches.

The original code was:
```js
replace(patch.pattern, `${patch.pattern}${patch.patch}`)
```
and that was replacing a found match with a regex & patch, e.g.:
```
/[^ \t]dependencies {\n
   compile()
}
```
since we never expected a `pattern` to be regexp.

The new code passes a function, that given a match for a given pattern, can use it to return a string to replace (e.g. match + pattern). That handles regexp being used as a pattern as we are given a real match. For plain strings, it works as previously.

Regexp can be tested here http://www.regexr.com/3dbbp