### PR TITLE
Preserve line breaks in settings.gradle

### DIFF
--- a/src/android/patches/makeSettingsPatch.js
+++ b/src/android/patches/makeSettingsPatch.js
@@ -21,6 +21,6 @@ module.exports = function makeSettingsPatch(name, androidConfig, projectConfig) 
     pattern: 'include \':app\'\n',
     patch: `include ':${name}'\n` +
       `project(':${name}').projectDir = ` +
-      `new File(rootProject.projectDir, '${projectDir}')`,
+      `new File(rootProject.projectDir, '${projectDir}')\n`,
   };
 };

--- a/test/android/patches/makeSettingsPatch.spec.js
+++ b/test/android/patches/makeSettingsPatch.spec.js
@@ -30,7 +30,7 @@ describe('makeSettingsPatch', () => {
       .to.be.equal(
         `include ':${name}'\n` +
         `project(':${name}').projectDir = ` +
-        `new File(rootProject.projectDir, '${projectDir}')`
+        `new File(rootProject.projectDir, '${projectDir}')\n`
       );
   });
 });


### PR DESCRIPTION
Fixes https://github.com/rnpm/rnpm/issues/153

Since the pattern is `include ':app:'\n`, we have to preserve the `\n` when we are done with inserting.