### PR TITLE
Support adding/removing iOS shared libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "plist": "^1.2.0",
     "semver": "^5.1.0",
     "to-camel-case": "^1.0.0",
-    "xcode": "^0.8.2"
+    "xcode": "^0.8.8"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.5",

--- a/src/ios/addSharedLibraries.js
+++ b/src/ios/addSharedLibraries.js
@@ -1,3 +1,16 @@
-module.exports = function addSharedLibraries(project, libraries) {
+const createGroupWithMessage = require('./createGroupWithMessage');
 
+module.exports = function addSharedLibraries(project, libraries) {
+  if (!libraries.length) {
+    return;
+  }
+
+  // Create a Frameworks group if necessary.
+  createGroupWithMessage(project, 'Frameworks');
+
+  const target = project.getFirstTarget().uuid;
+
+  for (var name of libraries) {
+    project.addFramework(name, { target });
+  }
 };

--- a/src/ios/copyAssets.js
+++ b/src/ios/copyAssets.js
@@ -4,7 +4,7 @@ const xcode = require('xcode');
 const log = require('npmlog');
 const plistParser = require('plist');
 const groupFilesByType = require('../groupFilesByType');
-const createGroup = require('./createGroup');
+const createGroupWithMessage = require('./createGroupWithMessage');
 const getPlist = require('./getPlist');
 const getPlistPath = require('./getPlistPath');
 
@@ -23,14 +23,7 @@ module.exports = function linkAssetsIOS(files, projectConfig) {
     );
   }
 
-  if (!project.pbxGroupByName('Resources')) {
-    createGroup(project, 'Resources');
-
-    log.warn(
-      'ERRGROUP',
-      `Group 'Resources' does not exist in your XCode project. We have created it automatically for you.`
-    );
-  }
+  createGroupWithMessage(project, 'Resources');
 
   const assets = files
     .map(asset =>

--- a/src/ios/createGroupWithMessage.js
+++ b/src/ios/createGroupWithMessage.js
@@ -1,0 +1,25 @@
+const log = require('npmlog');
+
+const createGroup = require('./createGroup');
+const getGroup = require('./getGroup');
+
+/**
+ * Given project and path of the group, it checks if a group exists at that path,
+ * and deeply creates a group for that path if its does not already exist.
+ *
+ * Returns the existing or newly created group
+ */
+module.exports = function createGroupWithMessage(project, path) {
+  var group = getGroup(project, path);
+
+  if (!group) {
+    group = createGroup(project, path);
+
+    log.warn(
+      'ERRGROUP',
+      `Group '${path}' does not exist in your XCode project. We have created it automatically for you.`
+    );
+  }
+
+  return group;
+};

--- a/src/ios/registerNativeModule.js
+++ b/src/ios/registerNativeModule.js
@@ -7,13 +7,12 @@ const addToHeaderSearchPaths = require('./addToHeaderSearchPaths');
 const getHeadersInFolder = require('./getHeadersInFolder');
 const getHeaderSearchPath = require('./getHeaderSearchPath');
 const getProducts = require('./getProducts');
-const createGroup = require('./createGroup');
+const createGroupWithMessage = require('./createGroupWithMessage');
 const hasLibraryImported = require('./hasLibraryImported');
 const addFileToProject = require('./addFileToProject');
 const addProjectToLibraries = require('./addProjectToLibraries');
 const addSharedLibraries = require('./addSharedLibraries');
 const isEmpty = require('lodash').isEmpty;
-const getGroup = require('./getGroup');
 
 /**
  * Register native module IOS adds given dependency to project by adding
@@ -26,16 +25,7 @@ module.exports = function registerNativeModuleIOS(dependencyConfig, projectConfi
   const project = xcode.project(projectConfig.pbxprojPath).parseSync();
   const dependencyProject = xcode.project(dependencyConfig.pbxprojPath).parseSync();
 
-  var libraries = getGroup(project, projectConfig.libraryFolder);
-
-  if (!libraries) {
-    libraries = createGroup(project, projectConfig.libraryFolder);
-
-    log.warn(
-      'ERRGROUP',
-      `Group ${projectConfig.libraryFolder} does not exist in your XCode project. We have created it automatically for you.`
-    );
-  }
+  const libraries = createGroupWithMessage(project, projectConfig.libraryFolder);
 
   const file = addFileToProject(
     project,

--- a/src/ios/removeSharedLibraries.js
+++ b/src/ios/removeSharedLibraries.js
@@ -1,3 +1,11 @@
 module.exports = function removeSharedLibraries(project, libraries) {
+  if (!libraries.length) {
+    return;
+  }
 
+  const target = project.getFirstTarget().uuid;
+
+  for (var name of libraries) {
+    project.removeFramework(name, { target });
+  }
 };

--- a/src/unlink.js
+++ b/src/unlink.js
@@ -88,8 +88,8 @@ module.exports = function unlink(config, args) {
   }
 
   const allDependencies = getDependencyConfig(config, getProjectDependencies());
-  const otherDependencies = filter(allDependencies, ({name}) => name !== packageName);
-  const iOSDependencies = compact(otherDependencies.map(({config}) => config.ios));
+  const otherDependencies = filter(allDependencies, d => d.name !== packageName);
+  const iOSDependencies = compact(otherDependencies.map(d => d.config.ios));
 
   unlinkDependencyAndroid(project.android, dependency, packageName);
   unlinkDependencyIOS(project.ios, dependency, packageName, iOSDependencies);

--- a/src/unlink.js
+++ b/src/unlink.js
@@ -9,7 +9,9 @@ const isInstalledIOS = require('./ios/isInstalled');
 const unlinkAssetsAndroid = require('./android/unlinkAssets');
 const unlinkAssetsIOS = require('./ios/unlinkAssets');
 const getDependencyConfig = require('./getDependencyConfig');
+const compact = require('lodash').compact;
 const difference = require('lodash').difference;
+const filter = require('lodash').filter;
 const isEmpty = require('lodash').isEmpty;
 const flatten = require('lodash').flatten;
 
@@ -34,7 +36,7 @@ const unlinkDependencyAndroid = (androidProject, dependency, packageName) => {
   log.info(`Android module ${packageName} has been successfully unlinked`);
 };
 
-const unlinkDependencyIOS = (iOSProject, dependency, packageName) => {
+const unlinkDependencyIOS = (iOSProject, dependency, packageName, iOSDependencies) => {
   if (!iOSProject || !dependency.ios) {
     return;
   }
@@ -48,7 +50,7 @@ const unlinkDependencyIOS = (iOSProject, dependency, packageName) => {
 
   log.info(`Unlinking ${packageName} ios dependency`);
 
-  unregisterDependencyIOS(dependency.ios, iOSProject);
+  unregisterDependencyIOS(dependency.ios, iOSProject, iOSDependencies);
 
   log.info(`iOS module ${packageName} has been successfully unlinked`);
 };
@@ -85,10 +87,12 @@ module.exports = function unlink(config, args) {
     return Promise.reject(err);
   }
 
-  unlinkDependencyAndroid(project.android, dependency, packageName);
-  unlinkDependencyIOS(project.ios, dependency, packageName);
-
   const allDependencies = getDependencyConfig(config, getProjectDependencies());
+  const otherDependencies = filter(allDependencies, ({name}) => name !== packageName);
+  const iOSDependencies = compact(otherDependencies.map(({config}) => config.ios));
+
+  unlinkDependencyAndroid(project.android, dependency, packageName);
+  unlinkDependencyIOS(project.ios, dependency, packageName, iOSDependencies);
 
   const assets = difference(
     dependency.assets,

--- a/test/ios/addSharedLibraries.spec.js
+++ b/test/ios/addSharedLibraries.spec.js
@@ -1,0 +1,40 @@
+const chai = require('chai');
+const expect = chai.expect;
+const xcode = require('xcode');
+const addSharedLibraries = require('../../src/ios/addSharedLibraries');
+const getGroup = require('../../src/ios/getGroup');
+
+const project = xcode.project('test/fixtures/project.pbxproj');
+
+describe('ios::addSharedLibraries', () => {
+
+  beforeEach(() => {
+    project.parseSync();
+  });
+
+  it('should automatically create Frameworks group', () => {
+    expect(getGroup(project, 'Frameworks')).to.equal(null);
+    addSharedLibraries(project, ['libz.tbd']);
+    expect(getGroup(project, 'Frameworks')).to.not.equal(null);
+  });
+
+  it('should add shared libraries to project', () => {
+    addSharedLibraries(project, ['libz.tbd']);
+
+    const frameworksGroup = getGroup(project, 'Frameworks');
+    expect(frameworksGroup.children.length).to.equal(1);
+    expect(frameworksGroup.children[0].comment).to.equal('libz.tbd');
+
+    addSharedLibraries(project, ['MessageUI.framework']);
+    expect(frameworksGroup.children.length).to.equal(2);
+  });
+
+  it('should not add duplicate libraries to project', () => {
+    addSharedLibraries(project, ['libz.tbd']);
+    addSharedLibraries(project, ['libz.tbd']);
+
+    const frameworksGroup = getGroup(project, 'Frameworks');
+    expect(frameworksGroup.children.length).to.equal(1);
+  });
+
+});

--- a/test/ios/removeSharedLibraries.spec.js
+++ b/test/ios/removeSharedLibraries.spec.js
@@ -1,0 +1,32 @@
+const chai = require('chai');
+const expect = chai.expect;
+const xcode = require('xcode');
+const addSharedLibraries = require('../../src/ios/addSharedLibraries');
+const removeSharedLibraries = require('../../src/ios/removeSharedLibraries');
+const getGroup = require('../../src/ios/getGroup');
+
+const project = xcode.project('test/fixtures/project.pbxproj');
+
+describe('ios::removeSharedLibraries', () => {
+
+  beforeEach(() => {
+    project.parseSync();
+    addSharedLibraries(project, ['libc++.tbd', 'libz.tbd']);
+  });
+
+  it('should remove only the specified shared library', () => {
+    removeSharedLibraries(project, ['libc++.tbd']);
+
+    const frameworksGroup = getGroup(project, 'Frameworks');
+    expect(frameworksGroup.children.length).to.equal(1);
+    expect(frameworksGroup.children[0].comment).to.equal('libz.tbd');
+  });
+
+  it('should ignore missing shared libraries', () => {
+    removeSharedLibraries(project, ['libxml2.tbd']);
+
+    const frameworksGroup = getGroup(project, 'Frameworks');
+    expect(frameworksGroup.children.length).to.equal(2);
+  });
+
+});


### PR DESCRIPTION
When removing shared libraries, only the ones not used by anyone else are removed.

The xcode module was updated to 0.8.8 for supporting `tbd` files (text-based dynamic library definitions).

This resolves rnpm/rnpm#122 and only works with rnpm/rnpm#172 merged, which provided the `sharedLibraries` array.