### PR TITLE
Fix bug where wrong assets are removed in unlink

### DIFF
--- a/src/unlink.js
+++ b/src/unlink.js
@@ -89,7 +89,7 @@ module.exports = function unlink(config, args) {
   unlinkDependencyIOS(project.ios, dependency, packageName);
 
   const allDependencies = getDependencyConfig(config, getProjectDependencies());
-  const otherDependencies = filter(allDependencies, ({name}) => name !== packageName);
+  const otherDependencies = filter(allDependencies, d => d.name !== packageName);
 
   const assets = difference(
     dependency.assets,

--- a/src/unlink.js
+++ b/src/unlink.js
@@ -10,8 +10,8 @@ const unlinkAssetsAndroid = require('./android/unlinkAssets');
 const unlinkAssetsIOS = require('./ios/unlinkAssets');
 const getDependencyConfig = require('./getDependencyConfig');
 const difference = require('lodash').difference;
+const filter = require('lodash').filter;
 const isEmpty = require('lodash').isEmpty;
-const flatten = require('lodash').flatten;
 
 log.heading = 'rnpm-link';
 
@@ -89,10 +89,14 @@ module.exports = function unlink(config, args) {
   unlinkDependencyIOS(project.ios, dependency, packageName);
 
   const allDependencies = getDependencyConfig(config, getProjectDependencies());
+  const otherDependencies = filter(allDependencies, ({name}) => name !== packageName);
 
   const assets = difference(
     dependency.assets,
-    flatten(allDependencies, d => d.assets)
+    otherDependencies.reduce(
+      (assets, dependency) => assets.concat(dependency.config.assets),
+      project.assets
+    )
   );
 
   if (isEmpty(assets)) {

--- a/test/getDependencyConfig.spec.js
+++ b/test/getDependencyConfig.spec.js
@@ -5,11 +5,13 @@ const sinon = require('sinon');
 
 describe('getDependencyConfig', () => {
   it('should return an array of dependencies\' rnpm config', () => {
+    const depenendencyConfig = {assets: []};
     const config = {
-      getDependencyConfig: sinon.stub(),
+      getDependencyConfig: sinon.stub().returns(depenendencyConfig),
     };
 
-    expect(getDependencyConfig(config, ['abcd'])).to.be.an.array;
+    const depenendencies = getDependencyConfig(config, ['abcd']);
+    expect(depenendencies).to.deep.equal([{name: 'abcd', config: depenendencyConfig}]);
     expect(config.getDependencyConfig.callCount).to.equals(1);
   });
 

--- a/test/unlink.spec.js
+++ b/test/unlink.spec.js
@@ -1,0 +1,120 @@
+const chai = require('chai');
+const expect = chai.expect;
+const sinon = require('sinon');
+const mock = require('mock-require');
+const log = require('npmlog');
+const path = require('path');
+
+const unlink = require('../src/unlink');
+
+log.level = 'silent';
+
+describe('unlink', () => {
+
+  beforeEach(() => {
+    delete require.cache[require.resolve('../src/unlink')];
+  });
+
+  it('should reject when run in a folder without package.json', (done) => {
+    const config = {
+      getProjectConfig: () => {
+        throw new Error('No package.json found');
+      },
+    };
+
+    unlink(config, ['react-native-gradient']).catch(() => done());
+  });
+
+  it('should accept a name of a dependency to unlink', (done) => {
+    const config = {
+      getProjectConfig: () => ({ assets: [] }),
+      getDependencyConfig: sinon.stub().returns({ assets: [], commands: {} }),
+    };
+
+    unlink(config, ['react-native-gradient']).then(() => {
+      expect(
+        config.getDependencyConfig.calledWith('react-native-gradient')
+      ).to.be.true;
+      done();
+    }).catch(done);
+  });
+
+  it('should unregister native module when android/ios projects are present', (done) => {
+    const unregisterNativeModule = sinon.stub();
+    const dependencyConfig = {android: {}, ios: {}, assets: [], commands: {}};
+    const config = {
+      getProjectConfig: () => ({android: {}, ios: {}, assets: []}),
+      getDependencyConfig: sinon.stub().returns(dependencyConfig),
+    };
+
+    mock(
+      '../src/android/isInstalled.js',
+      sinon.stub().returns(true)
+    );
+
+    mock(
+      '../src/android/unregisterNativeModule.js',
+      unregisterNativeModule
+    );
+
+    mock(
+      '../src/ios/isInstalled.js',
+      sinon.stub().returns(true)
+    );
+
+    mock(
+      '../src/ios/unregisterNativeModule.js',
+      unregisterNativeModule
+    );
+
+    const unlink = require('../src/unlink');
+
+    unlink(config, ['react-native-blur']).then(() => {
+      expect(unregisterNativeModule.calledTwice).to.be.true;
+      done();
+    }).catch(done);
+  });
+
+  it('should remove assets from dependency not used by project', (done) => {
+    const dependencyAssets = ['Fonts/FontA.ttf', 'Fonts/FontB.ttf', 'Fonts/FontC.ttf'];
+    const otherDependencyAssets = ['Fonts/FontB.ttf'];
+    const projectAssets = ['Fonts/FontC.ttf', 'Fonts/FontD.ttf'];
+    const getDependencyConfig = sinon.stub();
+    const unlinkAssets = sinon.stub();
+
+    getDependencyConfig.withArgs('react-native-blur').returns(
+      {assets: dependencyAssets, commands: {}}
+    );
+    getDependencyConfig.returns(
+      {assets: otherDependencyAssets, commands: {}}
+    );
+
+    const config = {
+      getDependencyConfig,
+      getProjectConfig: () => ({ios: {}, assets: projectAssets}),
+    };
+
+    mock(
+      '../src/getProjectDependencies',
+      () => ['react-native-blur', 'react-native-gradient']
+    );
+
+    mock(
+      '../src/ios/unlinkAssets.js',
+      unlinkAssets
+    );
+
+    const unlink = require('../src/unlink');
+
+    unlink(config, ['react-native-blur']).then(() => {
+      expect(unlinkAssets.calledOnce).to.be.true;
+      expect(unlinkAssets.firstCall.args[0]).to.deep.equal(['Fonts/FontA.ttf']);
+      done();
+    }).catch(done);
+  });
+
+  afterEach(() => {
+    mock.stopAll();
+  });
+
+});


### PR DESCRIPTION
The assets that should be kept were not properly specified. Also added a test for unlink that includes testing removing only the assets not used by other dependencies or the project itself.