### PR TITLE
Add option to skip linking for a platform

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,11 @@ module.exports = [{
   func: require('./src/link'),
   description: 'Links all native dependencies',
   name: 'link [packageName]',
+  options: [{
+    flags: '-s, --skip [platform]',
+    description: 'Skip linking for platform (android or ios)',
+    default: "",
+  }]
 }, {
   func: require('./src/unlink'),
   description: 'Unlink native dependency',

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = [{
   options: [{
     flags: '-s, --skip [platform]',
     description: 'Skip linking for platform (android or ios)',
-    default: '',
+    default: ''
   }]
 }, {
   func: require('./src/unlink'),

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = [{
   options: [{
     flags: '-s, --skip [platform]',
     description: 'Skip linking for platform (android or ios)',
-    default: "",
+    default: '',
   }]
 }, {
   func: require('./src/unlink'),

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ module.exports = [{
   options: [{
     flags: '-s, --skip [platform]',
     description: 'Skip linking for platform (android or ios)',
-    default: ''
-  }]
+    default: '',
+  }],
 }, {
   func: require('./src/unlink'),
   description: 'Unlink native dependency',

--- a/src/link.js
+++ b/src/link.js
@@ -26,7 +26,7 @@ const promisify = (func) => new Promise((resolve, reject) =>
 );
 
 const linkDependencyAndroid = (androidProject, dependency, options) => {
-  if (!androidProject || !dependency.config.android || options.skip == 'android') {
+  if (!androidProject || !dependency.config.android || options.skip === 'android') {
     return null;
   }
 
@@ -52,7 +52,7 @@ const linkDependencyAndroid = (androidProject, dependency, options) => {
 };
 
 const linkDependencyIOS = (iOSProject, dependency, options) => {
-  if (!iOSProject || !dependency.config.ios || options.skip == 'ios') {
+  if (!iOSProject || !dependency.config.ios || options.skip === 'ios') {
     return;
   }
 
@@ -75,12 +75,12 @@ const linkAssets = (project, assets, options) => {
     return;
   }
 
-  if (project.ios && options.skip != 'ios') {
+  if (project.ios && options.skip !== 'ios') {
     log.info('Linking assets to ios project');
     copyAssetsIOS(assets, project.ios);
   }
 
-  if (project.android && options.skip != 'android') {
+  if (project.android && options.skip !== 'android') {
     log.info('Linking assets to android project');
     copyAssetsAndroid(assets, project.android.assetsPath);
   }


### PR DESCRIPTION
I am using cocoapods to manage some dependencies so found it handy to skip linking these modules for iOS e.g:
`rnpm link  react-native-fbsdk --skip ios`
