### PR TITLE
`include 'app'\n` is not a necessary string

### DIFF
--- a/src/android/patches/makeSettingsPatch.js
+++ b/src/android/patches/makeSettingsPatch.js
@@ -18,7 +18,7 @@ module.exports = function makeSettingsPatch(name, androidConfig, projectConfig) 
   }
 
   return {
-    pattern: 'include \':app\'\n',
+    pattern: '\n',
     patch: `include ':${name}'\n` +
       `project(':${name}').projectDir = ` +
       `new File(rootProject.projectDir, '${projectDir}')\n`,


### PR DESCRIPTION
For example in f8app it does not appear.
instead there is `include ':app', ':react-native-linear-gradient'`
Some other projects might do something like `include ':react-native-send-intent', ':app'`
